### PR TITLE
Bringing the option allowCovered to the BrowserSideOptions interface

### DIFF
--- a/action_helpers/find.ts
+++ b/action_helpers/find.ts
@@ -17,6 +17,7 @@ interface BrowserSidePositionalLocator {
 
 export interface BrowserSideOptions {
   allowUnseen?: boolean;
+  allowCovered?: boolean;
   wantZero?: boolean;
   enabled?: boolean;
   disabled?: boolean;


### PR DESCRIPTION
# What
Adding the **allowCovered** option to the browserSideOptions interface. 

# Why
So that this option can be passed in the see and click methods exported by this package. With this option system will be able to find elements which are outside the current view ,  like is the element being searched in outside the horizontal scroll area.